### PR TITLE
Replacing the #file macro with #fileID

### DIFF
--- a/AppMetricaLogSwift/Sources/Log.swift
+++ b/AppMetricaLogSwift/Sources/Log.swift
@@ -17,7 +17,7 @@ public final class Logger {
         self.channel = channel
     }
     
-    func message(_ str: String, level: LogLevel, file: StaticString = #file, line: UInt = #line, function: StaticString = #function) {
+    func message(_ str: String, level: LogLevel, file: StaticString = #fileID, line: UInt = #line, function: StaticString = #function) {
         facade.logMessage(toChannel: channel as String,
                           level: level.appMetricaLogLevel,
                           file: file.utf8Start,
@@ -27,23 +27,23 @@ public final class Logger {
                           message: str)
     }
     
-    public func info(_ str: String, file: StaticString = #file, line: UInt = #line, function: StaticString = #function) {
+    public func info(_ str: String, file: StaticString = #fileID, line: UInt = #line, function: StaticString = #function) {
         message(str, level: .info, file: file, line: line, function: function)
     }
     
-    public func warning(_ str: String, file: StaticString = #file, line: UInt = #line, function: StaticString = #function) {
+    public func warning(_ str: String, file: StaticString = #fileID, line: UInt = #line, function: StaticString = #function) {
         message(str, level: .warning, file: file, line: line, function: function)
     }
     
-    public func error(_ str: String, file: StaticString = #file, line: UInt = #line, function: StaticString = #function) {
+    public func error(_ str: String, file: StaticString = #fileID, line: UInt = #line, function: StaticString = #function) {
         message(str, level: .error, file: file, line: line, function: function)
     }
     
-    public func notify(_ str: String, file: StaticString = #file, line: UInt = #line, function: StaticString = #function) {
+    public func notify(_ str: String, file: StaticString = #fileID, line: UInt = #line, function: StaticString = #function) {
         message(str, level: .notify, file: file, line: line, function: function)
     }
     
-    public func error(_ error: Error, file: StaticString = #file, line: UInt = #line, function: StaticString = #function) {
+    public func error(_ error: Error, file: StaticString = #fileID, line: UInt = #line, function: StaticString = #function) {
         message(String(describing: error), level: .error, file: file, line: line, function: function)
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru 

### Pull Request Description  

**Replacing the `#file` macro with `#fileID`**  

#### Justification for Changes:  
1. **Compliance with Apple's Recommendations**  
   The `#fileID` macro is the preferred approach recommended by Apple, unlike `#file`, which includes the full file path in the build.  

2. **Reduction of Information Security Risks**  
   Using `#file` may expose internal directory structures and build paths, posing a potential security risk. `#fileID` provides only the filename and module name, which is sufficient for logging and debugging while avoiding unnecessary information disclosure.  

3. **Cleaner Logs**  
   Full paths in logs do not provide practical value but increase log size. `#fileID` makes logs more concise and readable.  

#### Changes:  
- All occurrences of `#file` replaced with `#fileID` in the relevant code.  
- Logs and diagnostic messages now contain only essential information (filename and module name).  

#### Impact:  
- Improved security without loss of functionality.  
- Cleaner and more relevant logs.  
